### PR TITLE
chore: GitHub Actions CI パイプラインを構築 (#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v4
+
+      - name: .NET 9 SDK をセットアップ
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: NuGet パッケージを復元
+        run: dotnet restore TodoApp.sln
+
+      - name: ソリューションをビルド
+        run: dotnet build TodoApp.sln --no-restore --configuration Release
+
+      - name: テストを実行
+        run: dotnet test TodoApp.sln --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
+
+      - name: テスト結果をアップロード
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: "**/TestResults/*.trx"
+          retention-days: 30


### PR DESCRIPTION
## 概要
- PR 作成時および main ブランチへの push 時に、build → test を自動実行する GitHub Actions CI ワークフローを追加
- .NET 9 SDK セットアップ、NuGet 復元、Release ビルド、テスト実行を一連のステップで実行
- テスト結果を trx 形式でアーティファクトとして保存

## 関連 Issue
Closes #5

## テスト計画
- [x] `dotnet restore` が成功すること
- [x] `dotnet build --configuration Release` が成功すること（0 Warning, 0 Error）
- [x] `dotnet test --configuration Release` で全 12 テストが Pass すること
- [ ] PR 作成後、GitHub Actions の CI ジョブが自動起動すること
- [ ] CI ジョブが正常に完了し、テスト結果が PR に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)