### PR TITLE
feat: ログインユーザー情報取得APIを実装 (#8)

### DIFF
--- a/src/TodoApp.Api/Endpoints/AuthEndpoints.cs
+++ b/src/TodoApp.Api/Endpoints/AuthEndpoints.cs
@@ -1,0 +1,32 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using TodoApp.Api.Data;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Api.Endpoints;
+
+public static class AuthEndpoints
+{
+    public static void MapAuthEndpoints(this WebApplication app)
+    {
+        app.MapGet("/api/auth/me", async (ClaimsPrincipal user, TodoAppDbContext db) =>
+        {
+            var userIdClaim = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdClaim is null || !int.TryParse(userIdClaim, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            var dbUser = await db.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == userId);
+
+            if (dbUser is null)
+            {
+                return Results.NotFound();
+            }
+
+            return Results.Ok(new UserResponse(dbUser.Id, dbUser.Email, dbUser.DisplayName, dbUser.Role));
+        }).RequireAuthorization();
+    }
+}

--- a/src/TodoApp.Api/Program.cs
+++ b/src/TodoApp.Api/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using TodoApp.Api.Data;
+using TodoApp.Api.Endpoints;
 using TodoApp.Api.Exceptions;
 using TodoApp.Api.Middleware;
 
@@ -81,6 +82,8 @@ app.MapGet("/weatherforecast", () =>
 
 app.MapGet("/test/auth", () => "Authenticated!")
     .RequireAuthorization();
+
+app.MapAuthEndpoints();
 
 app.Run();
 

--- a/src/TodoApp.Shared/Responses/UserResponse.cs
+++ b/src/TodoApp.Shared/Responses/UserResponse.cs
@@ -1,0 +1,5 @@
+using TodoApp.Shared.Models;
+
+namespace TodoApp.Shared.Responses;
+
+public record UserResponse(int Id, string Email, string DisplayName, UserRole Role);

--- a/tests/TodoApp.Api.Tests/AuthMeTests.cs
+++ b/tests/TodoApp.Api.Tests/AuthMeTests.cs
@@ -1,0 +1,122 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using TodoApp.Api.Data;
+using TodoApp.Api.Data.Entities;
+using TodoApp.Shared.Models;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Api.Tests;
+
+public class AuthMeTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private const string JwtKey = "dev-only-jwt-secret-key-minimum-32-characters-long!!";
+    private const string JwtIssuer = "TodoApp";
+    private const string JwtAudience = "TodoApp";
+
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public AuthMeTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                // 既存の DbContext 登録を削除して InMemory SQLite に差し替え
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<TodoAppDbContext>));
+                if (descriptor != null)
+                    services.Remove(descriptor);
+
+                var connection = new Microsoft.Data.Sqlite.SqliteConnection("DataSource=:memory:");
+                connection.Open();
+
+                services.AddDbContext<TodoAppDbContext>(options =>
+                    options.UseSqlite(connection));
+
+                // DB を初期化してテストユーザーを作成
+                var sp = services.BuildServiceProvider();
+                using var scope = sp.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<TodoAppDbContext>();
+                db.Database.EnsureCreated();
+                db.Users.Add(new User
+                {
+                    Id = 1,
+                    Email = "test@example.com",
+                    DisplayName = "テストユーザー",
+                    PasswordHash = "dummy-hash",
+                    Role = UserRole.Member
+                });
+                db.SaveChanges();
+            });
+        });
+    }
+
+    [Fact]
+    public async Task 認証なしでアクセスすると401が返る()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/auth/me");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task 認証済みユーザーでアクセスすると200とユーザー情報が返る()
+    {
+        var client = _factory.CreateClient();
+        var token = GenerateTestToken(userId: "1", email: "test@example.com");
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/api/auth/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var user = await response.Content.ReadFromJsonAsync<UserResponse>();
+        Assert.NotNull(user);
+        Assert.Equal(1, user.Id);
+        Assert.Equal("test@example.com", user.Email);
+        Assert.Equal("テストユーザー", user.DisplayName);
+        Assert.Equal(UserRole.Member, user.Role);
+    }
+
+    [Fact]
+    public async Task 存在しないユーザーIDの場合404が返る()
+    {
+        var client = _factory.CreateClient();
+        var token = GenerateTestToken(userId: "999", email: "unknown@example.com");
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync("/api/auth/me");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private static string GenerateTestToken(string userId, string email)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(ClaimTypes.Email, email)
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: JwtIssuer,
+            audience: JwtAudience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(15),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
## 概要
- GET `/api/auth/me` エンドポイントを追加（`RequireAuthorization()` 設定済み）
- JWT Claims の `NameIdentifier` からユーザーIDを取得し、DBからユーザー情報を返却
- `UserResponse` DTO（Id, Email, DisplayName, Role）を新規作成
- Minimal API パターンで `AuthEndpoints` として実装

## 関連 Issue
Closes #8

## テスト計画
- [x] 認証なしでアクセスすると 401 Unauthorized が返る
- [x] 認証済みユーザーでアクセスすると 200 OK とユーザー情報（Id, Email, DisplayName, Role）が返る
- [x] JWT に含まれるユーザーIDがDBに存在しない場合 404 Not Found が返る
- [x] 既存テスト（14件）が全て通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)