### PR TITLE
feat: Todo詳細取得APIを実装 (#15)

### DIFF
--- a/src/TodoApp.Api/Endpoints/TodoEndpoints.cs
+++ b/src/TodoApp.Api/Endpoints/TodoEndpoints.cs
@@ -34,6 +34,12 @@ public static class TodoEndpoints
             return Results.Created($"/api/todos/{response.Id}", response);
         }).RequireAuthorization();
 
+        app.MapGet("/api/todos/{id:int}", async (int id, ITodoService todoService, CancellationToken cancellationToken) =>
+        {
+            var todo = await todoService.GetByIdAsync(id, cancellationToken);
+            return Results.Ok(todo);
+        }).RequireAuthorization();
+
         app.MapPatch("/api/todos/{id:int}/status", async (int id, UpdateTodoStatusRequest request, ITodoService todoService, CancellationToken cancellationToken) =>
         {
             if (!Enum.IsDefined(typeof(TodoStatus), request.Status))

--- a/src/TodoApp.Api/Services/ITodoService.cs
+++ b/src/TodoApp.Api/Services/ITodoService.cs
@@ -6,5 +6,6 @@ namespace TodoApp.Api.Services;
 public interface ITodoService
 {
     Task<TodoResponse> CreateAsync(CreateTodoRequest request, int createdByUserId, CancellationToken cancellationToken = default);
+    Task<TodoResponse> GetByIdAsync(int id, CancellationToken cancellationToken = default);
     Task<TodoResponse> UpdateStatusAsync(int id, UpdateTodoStatusRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/TodoApp.Api/Services/TodoService.cs
+++ b/src/TodoApp.Api/Services/TodoService.cs
@@ -41,6 +41,38 @@ public class TodoService(TodoAppDbContext dbContext) : ITodoService
         return MapToResponse(todoItem);
     }
 
+    public async Task<TodoResponse> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var todo = await dbContext.TodoItems
+            .AsNoTracking()
+            .Include(t => t.CreatedBy)
+            .Include(t => t.AssignedTo)
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+        if (todo is null)
+        {
+            throw new NotFoundException("指定されたTodoが見つかりません");
+        }
+
+        return new TodoResponse
+        {
+            Id = todo.Id,
+            Title = todo.Title,
+            Description = todo.Description,
+            Status = todo.Status,
+            Priority = todo.Priority,
+            ProgressRate = todo.ProgressRate,
+            DueDate = todo.DueDate,
+            CompletedAt = todo.CompletedAt,
+            CreatedByUserId = todo.CreatedByUserId,
+            AssignedToUserId = todo.AssignedToUserId,
+            CreatedByName = todo.CreatedBy.DisplayName,
+            AssignedToName = todo.AssignedTo?.DisplayName,
+            CreatedAt = todo.CreatedAt,
+            UpdatedAt = todo.UpdatedAt
+        };
+    }
+
     public async Task<TodoResponse> UpdateStatusAsync(int id, UpdateTodoStatusRequest request, CancellationToken cancellationToken = default)
     {
         var todoItem = await dbContext.TodoItems.FindAsync([id], cancellationToken)

--- a/src/TodoApp.Shared/Responses/TodoResponse.cs
+++ b/src/TodoApp.Shared/Responses/TodoResponse.cs
@@ -11,8 +11,11 @@ public class TodoResponse
     public Priority Priority { get; set; }
     public int ProgressRate { get; set; }
     public DateTime? DueDate { get; set; }
+    public DateTime? CompletedAt { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
     public int CreatedByUserId { get; set; }
     public int? AssignedToUserId { get; set; }
+    public string CreatedByName { get; set; } = string.Empty;
+    public string? AssignedToName { get; set; }
 }

--- a/tests/TodoApp.Api.Tests/TodoDetailTests.cs
+++ b/tests/TodoApp.Api.Tests/TodoDetailTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TodoApp.Api.Data;
+using TodoApp.Api.Data.Entities;
+using TodoApp.Shared.Models;
+using TodoApp.Shared.Requests;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Api.Tests;
+
+public class TodoDetailTests : IClassFixture<WebApplicationFactory<Program>>, IDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly SqliteConnection _connection;
+
+    public TodoDetailTests(WebApplicationFactory<Program> factory)
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<TodoAppDbContext>));
+                if (descriptor != null)
+                    services.Remove(descriptor);
+
+                services.AddDbContext<TodoAppDbContext>(options =>
+                    options.UseSqlite(_connection));
+            });
+        });
+
+        _client = _factory.CreateClient();
+
+        // テスト用データをセットアップ
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TodoAppDbContext>();
+        db.Database.EnsureCreated();
+
+        var user = new User
+        {
+            Email = "test@example.com",
+            DisplayName = "テストユーザー",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!")
+        };
+        var assignee = new User
+        {
+            Email = "assignee@example.com",
+            DisplayName = "担当者",
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!")
+        };
+        db.Users.AddRange(user, assignee);
+        db.SaveChanges();
+
+        var todo = new TodoItem
+        {
+            Title = "テストTodo",
+            Description = "テスト用の説明",
+            Status = TodoStatus.InProgress,
+            Priority = Priority.High,
+            ProgressRate = 50,
+            DueDate = new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc),
+            CreatedByUserId = user.Id,
+            AssignedToUserId = assignee.Id
+        };
+        db.TodoItems.Add(todo);
+        db.SaveChanges();
+    }
+
+    private async Task<string> GetTokenAsync()
+    {
+        var loginRequest = new LoginRequest
+        {
+            Email = "test@example.com",
+            Password = "Password123!"
+        };
+        var loginResponse = await _client.PostAsJsonAsync("/api/auth/login", loginRequest);
+        var authResult = await loginResponse.Content.ReadFromJsonAsync<AuthResponse>();
+        return authResult!.Token!;
+    }
+
+    [Fact]
+    public async Task 存在するTodoのIDを指定すると200で詳細が返る()
+    {
+        var token = await GetTokenAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _client.GetAsync("/api/todos/1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var todo = await response.Content.ReadFromJsonAsync<TodoResponse>();
+        Assert.NotNull(todo);
+        Assert.Equal(1, todo.Id);
+        Assert.Equal("テストTodo", todo.Title);
+        Assert.Equal("テスト用の説明", todo.Description);
+        Assert.Equal(TodoStatus.InProgress, todo.Status);
+        Assert.Equal(Priority.High, todo.Priority);
+        Assert.Equal(50, todo.ProgressRate);
+        Assert.Equal("テストユーザー", todo.CreatedByName);
+        Assert.Equal("担当者", todo.AssignedToName);
+    }
+
+    [Fact]
+    public async Task 存在しないTodoのIDを指定すると404が返る()
+    {
+        var token = await GetTokenAsync();
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _client.GetAsync("/api/todos/9999");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task 認証なしでアクセスすると401が返る()
+    {
+        var response = await _client.GetAsync("/api/todos/1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        _connection.Dispose();
+    }
+}


### PR DESCRIPTION
## 概要
- `GET /api/todos/{id}` エンドポイントを追加（JWT認証必須）
- `ITodoService` / `TodoService` でTodo詳細取得のビジネスロジックを実装
- `TodoResponse` DTO を追加（作成者名・担当者名を含む）
- 存在しないTodoへのアクセスは `NotFoundException` で404を返却

## 関連 Issue
Closes #15

## テスト計画
- [x] 存在するTodoのIDを指定すると200で詳細情報が返る
- [x] 存在しないTodoのIDを指定すると404が返る
- [x] 認証なしでアクセスすると401が返る
- [x] 全テスト（30件）がパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)