### PR TITLE
feat: ユーザー登録画面を実装 (#25)

### DIFF
--- a/src/TodoApp.Client/Pages/Register.razor
+++ b/src/TodoApp.Client/Pages/Register.razor
@@ -1,0 +1,64 @@
+@page "/register"
+@inject IAuthApiClient AuthApiClient
+@inject NavigationManager NavigationManager
+
+<h2>ユーザー登録</h2>
+
+<EditForm Model="@_model" OnValidSubmit="HandleRegisterAsync" FormName="registerForm">
+    <DataAnnotationsValidator />
+
+    <div class="form-group mb-3">
+        <label for="email">メールアドレス</label>
+        <InputText id="email" type="email" class="form-control" @bind-Value="_model.Email" />
+        <ValidationMessage For="@(() => _model.Email)" />
+    </div>
+
+    <div class="form-group mb-3">
+        <label for="password">パスワード</label>
+        <InputText id="password" type="password" class="form-control" @bind-Value="_model.Password" />
+        <ValidationMessage For="@(() => _model.Password)" />
+    </div>
+
+    <div class="form-group mb-3">
+        <label for="displayName">表示名</label>
+        <InputText id="displayName" class="form-control" @bind-Value="_model.DisplayName" />
+        <ValidationMessage For="@(() => _model.DisplayName)" />
+    </div>
+
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="alert alert-danger error-message" role="alert">
+            @_errorMessage
+        </div>
+    }
+
+    <button type="submit" class="btn btn-primary">登録</button>
+</EditForm>
+
+<p class="mt-3">
+    既にアカウントをお持ちの方は <a href="login">ログイン</a> してください。
+</p>
+
+@code {
+    private RegisterRequest _model = new();
+    private string? _errorMessage;
+
+    private async Task HandleRegisterAsync()
+    {
+        _errorMessage = null;
+
+        try
+        {
+            await AuthApiClient.RegisterAsync(_model);
+            NavigationManager.NavigateTo("/login");
+        }
+        catch (HttpRequestException ex)
+        {
+            _errorMessage = ex.Message;
+        }
+        catch (Exception)
+        {
+            _errorMessage = "登録中にエラーが発生しました。しばらくしてから再度お試しください。";
+        }
+    }
+}

--- a/src/TodoApp.Client/Program.cs
+++ b/src/TodoApp.Client/Program.cs
@@ -1,11 +1,17 @@
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using TodoApp.Client;
+using TodoApp.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<AuthStateProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<AuthStateProvider>());
+builder.Services.AddScoped<IAuthApiClient, AuthApiClient>();
+builder.Services.AddAuthorizationCore();
 
 await builder.Build().RunAsync();

--- a/src/TodoApp.Client/Services/AuthApiClient.cs
+++ b/src/TodoApp.Client/Services/AuthApiClient.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+using TodoApp.Shared.Requests;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Services;
+
+public class AuthApiClient : IAuthApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public AuthApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<AuthResponse> RegisterAsync(RegisterRequest request)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/auth/register", request);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<AuthResponse>()
+            ?? throw new InvalidOperationException("レスポンスのデシリアライズに失敗しました。");
+    }
+
+    public async Task<AuthResponse> LoginAsync(LoginRequest request)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/auth/login", request);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<AuthResponse>()
+            ?? throw new InvalidOperationException("レスポンスのデシリアライズに失敗しました。");
+    }
+
+    public async Task<UserResponse> GetMeAsync()
+    {
+        var response = await _httpClient.GetAsync("api/auth/me");
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<UserResponse>()
+            ?? throw new InvalidOperationException("レスポンスのデシリアライズに失敗しました。");
+    }
+}

--- a/src/TodoApp.Client/Services/AuthStateProvider.cs
+++ b/src/TodoApp.Client/Services/AuthStateProvider.cs
@@ -1,0 +1,78 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.JSInterop;
+
+namespace TodoApp.Client.Services;
+
+public class AuthStateProvider : AuthenticationStateProvider
+{
+    private const string TokenKey = "authToken";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly HttpClient _httpClient;
+
+    public AuthStateProvider(IJSRuntime jsRuntime, HttpClient httpClient)
+    {
+        _jsRuntime = jsRuntime;
+        _httpClient = httpClient;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var token = await _jsRuntime.InvokeAsync<string>("localStorage.getItem", TokenKey);
+
+        if (string.IsNullOrEmpty(token))
+        {
+            return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+        }
+
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var claims = ParseClaimsFromJwt(token);
+        var identity = new ClaimsIdentity(claims, "jwt");
+        var user = new ClaimsPrincipal(identity);
+
+        return new AuthenticationState(user);
+    }
+
+    public async Task MarkUserAsAuthenticatedAsync(string token)
+    {
+        await _jsRuntime.InvokeVoidAsync("localStorage.setItem", TokenKey, token);
+
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var claims = ParseClaimsFromJwt(token);
+        var identity = new ClaimsIdentity(claims, "jwt");
+        var user = new ClaimsPrincipal(identity);
+
+        NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(user)));
+    }
+
+    public async Task MarkUserAsLoggedOutAsync()
+    {
+        await _jsRuntime.InvokeVoidAsync("localStorage.removeItem", TokenKey);
+
+        _httpClient.DefaultRequestHeaders.Authorization = null;
+
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+        NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(anonymous)));
+    }
+
+    private static IEnumerable<Claim> ParseClaimsFromJwt(string token)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(token);
+            return jwtToken.Claims;
+        }
+        catch
+        {
+            return Enumerable.Empty<Claim>();
+        }
+    }
+}

--- a/src/TodoApp.Client/Services/IAuthApiClient.cs
+++ b/src/TodoApp.Client/Services/IAuthApiClient.cs
@@ -1,0 +1,11 @@
+using TodoApp.Shared.Requests;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Services;
+
+public interface IAuthApiClient
+{
+    Task<AuthResponse> RegisterAsync(RegisterRequest request);
+    Task<AuthResponse> LoginAsync(LoginRequest request);
+    Task<UserResponse> GetMeAsync();
+}

--- a/src/TodoApp.Client/TodoApp.Client.csproj
+++ b/src/TodoApp.Client/TodoApp.Client.csproj
@@ -8,7 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TodoApp.Client/_Imports.razor
+++ b/src/TodoApp.Client/_Imports.razor
@@ -8,3 +8,6 @@
 @using Microsoft.JSInterop
 @using TodoApp.Client
 @using TodoApp.Client.Layout
+@using TodoApp.Client.Services
+@using TodoApp.Shared.Requests
+@using TodoApp.Shared.Responses

--- a/tests/TodoApp.Client.Tests/Pages/RegisterPageTest.cs
+++ b/tests/TodoApp.Client.Tests/Pages/RegisterPageTest.cs
@@ -1,0 +1,114 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using TodoApp.Client.Pages;
+using TodoApp.Client.Services;
+using TodoApp.Shared.Requests;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Tests.Pages;
+
+public class RegisterPageTest : TestContext
+{
+    private readonly Mock<IAuthApiClient> _mockAuthApiClient;
+
+    public RegisterPageTest()
+    {
+        _mockAuthApiClient = new Mock<IAuthApiClient>();
+        Services.AddSingleton(_mockAuthApiClient.Object);
+    }
+
+    [Fact]
+    public void Register_ページが正しくレンダリングされる()
+    {
+        var cut = RenderComponent<Register>();
+
+        Assert.NotNull(cut.Find("input[type='email']"));
+        Assert.NotNull(cut.Find("input[type='password']"));
+        Assert.NotNull(cut.Find("input[id='displayName']"));
+        Assert.NotNull(cut.Find("button[type='submit']"));
+    }
+
+    [Fact]
+    public void Register_ログイン画面へのリンクが表示される()
+    {
+        var cut = RenderComponent<Register>();
+
+        var link = cut.Find("a[href='login']");
+        Assert.NotNull(link);
+    }
+
+    [Fact]
+    public async Task Register_正常な入力で登録成功時にログイン画面へ遷移する()
+    {
+        _mockAuthApiClient
+            .Setup(x => x.RegisterAsync(It.IsAny<RegisterRequest>()))
+            .ReturnsAsync(new AuthResponse
+            {
+                UserId = 1,
+                Email = "test@example.com",
+                DisplayName = "テストユーザー",
+                Token = "dummy-token"
+            });
+
+        var navManager = Services.GetRequiredService<Bunit.TestDoubles.FakeNavigationManager>();
+        var cut = RenderComponent<Register>();
+
+        cut.Find("input[type='email']").Change("test@example.com");
+        cut.Find("input[type='password']").Change("password123");
+        cut.Find("input[id='displayName']").Change("テストユーザー");
+
+        await cut.Find("form").SubmitAsync();
+
+        _mockAuthApiClient.Verify(
+            x => x.RegisterAsync(It.Is<RegisterRequest>(r =>
+                r.Email == "test@example.com" &&
+                r.Password == "password123" &&
+                r.DisplayName == "テストユーザー")),
+            Times.Once);
+
+        Assert.EndsWith("/login", navManager.Uri);
+    }
+
+    [Fact]
+    public async Task Register_API失敗時にエラーメッセージが表示される()
+    {
+        _mockAuthApiClient
+            .Setup(x => x.RegisterAsync(It.IsAny<RegisterRequest>()))
+            .ThrowsAsync(new HttpRequestException("このメールアドレスは既に登録されています"));
+
+        var cut = RenderComponent<Register>();
+
+        cut.Find("input[type='email']").Change("test@example.com");
+        cut.Find("input[type='password']").Change("password123");
+        cut.Find("input[id='displayName']").Change("テストユーザー");
+
+        await cut.Find("form").SubmitAsync();
+
+        var errorMessage = cut.Find("[class*='error']");
+        Assert.NotNull(errorMessage);
+        Assert.Contains("メールアドレスは既に登録されています", errorMessage.TextContent);
+    }
+
+    [Fact]
+    public async Task Register_バリデーションエラー時にAPIが呼ばれない()
+    {
+        var cut = RenderComponent<Register>();
+
+        // Submit empty form
+        await cut.Find("form").SubmitAsync();
+
+        _mockAuthApiClient.Verify(
+            x => x.RegisterAsync(It.IsAny<RegisterRequest>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void Register_ページタイトルが表示される()
+    {
+        var cut = RenderComponent<Register>();
+
+        var heading = cut.Find("h2");
+        Assert.Contains("ユーザー登録", heading.TextContent);
+    }
+}

--- a/tests/TodoApp.Client.Tests/TodoApp.Client.Tests.csproj
+++ b/tests/TodoApp.Client.Tests/TodoApp.Client.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="bunit" Version="1.36.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## 概要
- EditForm + DataAnnotationsValidator によるバリデーション付き登録フォーム
- メールアドレス・パスワード・表示名の入力フィールド
- 登録成功時に /login へ遷移、失敗時にエラーメッセージ表示

## 関連 Issue
Closes #25

## テスト計画
- [x] ページレンダリングテスト
- [x] ログイン画面へのリンク表示テスト
- [x] 登録成功時の遷移テスト
- [x] API失敗時のエラー表示テスト
- [x] バリデーションエラーテスト
- [x] ページタイトル表示テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)