### PR TITLE
feat: UserSelectコンポーネントを実装 (#29)

### DIFF
--- a/src/TodoApp.Client/Components/UserSelect.razor
+++ b/src/TodoApp.Client/Components/UserSelect.razor
@@ -1,0 +1,46 @@
+@using TodoApp.Client.Services
+@using TodoApp.Shared.Responses
+@inject IUserApiClient UserApiClient
+
+<label>@Label</label>
+<select value="@SelectedUserIdString" @onchange="OnSelectionChanged" disabled="@_isLoading">
+    <option value="">未割当</option>
+    @if (_users is not null)
+    {
+        @foreach (var user in _users)
+        {
+            <option value="@user.Id">@user.DisplayName</option>
+        }
+    }
+</select>
+
+@code {
+    private List<UserResponse>? _users;
+    private bool _isLoading = true;
+
+    [Parameter]
+    public int? SelectedUserId { get; set; }
+
+    [Parameter]
+    public EventCallback<int?> SelectedUserIdChanged { get; set; }
+
+    [Parameter]
+    public string Label { get; set; } = "担当者";
+
+    private string SelectedUserIdString => SelectedUserId?.ToString() ?? "";
+
+    protected override async Task OnInitializedAsync()
+    {
+        _isLoading = true;
+        _users = await UserApiClient.GetUsersAsync();
+        _isLoading = false;
+    }
+
+    private async Task OnSelectionChanged(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString();
+        int? userId = string.IsNullOrEmpty(value) ? null : int.Parse(value);
+        SelectedUserId = userId;
+        await SelectedUserIdChanged.InvokeAsync(userId);
+    }
+}

--- a/src/TodoApp.Client/Program.cs
+++ b/src/TodoApp.Client/Program.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using TodoApp.Client;
+using TodoApp.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<IUserApiClient, UserApiClient>();
 
 await builder.Build().RunAsync();

--- a/src/TodoApp.Client/Services/IUserApiClient.cs
+++ b/src/TodoApp.Client/Services/IUserApiClient.cs
@@ -1,0 +1,15 @@
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Services;
+
+/// <summary>
+/// ユーザーAPI呼び出しクライアントのインターフェース
+/// </summary>
+public interface IUserApiClient
+{
+    /// <summary>
+    /// ユーザー一覧を取得する
+    /// </summary>
+    /// <returns>ユーザー一覧</returns>
+    Task<List<UserResponse>> GetUsersAsync();
+}

--- a/src/TodoApp.Client/Services/UserApiClient.cs
+++ b/src/TodoApp.Client/Services/UserApiClient.cs
@@ -1,0 +1,27 @@
+using System.Net.Http.Json;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Services;
+
+/// <summary>
+/// ユーザーAPIを呼び出すHTTPクライアント
+/// </summary>
+public class UserApiClient : IUserApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public UserApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    /// <inheritdoc />
+    public async Task<List<UserResponse>> GetUsersAsync()
+    {
+        var response = await _httpClient.GetAsync("api/users");
+        response.EnsureSuccessStatusCode();
+
+        var users = await response.Content.ReadFromJsonAsync<List<UserResponse>>();
+        return users ?? [];
+    }
+}

--- a/tests/TodoApp.Client.Tests/Components/UserSelectTests.cs
+++ b/tests/TodoApp.Client.Tests/Components/UserSelectTests.cs
@@ -1,0 +1,187 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using TodoApp.Client.Components;
+using TodoApp.Client.Services;
+using TodoApp.Shared.Models;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Tests.Components;
+
+public class UserSelectTests : TestContext
+{
+    private readonly Mock_UserApiClient _mockUserApiClient = new();
+
+    public UserSelectTests()
+    {
+        Services.AddSingleton<IUserApiClient>(_mockUserApiClient);
+    }
+
+    [Fact]
+    public void ユーザー一覧がドロップダウンに表示される()
+    {
+        // Arrange
+        var users = new List<UserResponse>
+        {
+            new(1, "user1@example.com", "ユーザー1", UserRole.Member),
+            new(2, "user2@example.com", "ユーザー2", UserRole.Admin),
+        };
+        _mockUserApiClient.UsersToReturn = users;
+
+        // Act
+        var cut = RenderComponent<UserSelect>();
+        cut.WaitForState(() => cut.FindAll("option").Count > 1);
+
+        // Assert
+        var options = cut.FindAll("option");
+        Assert.Equal(3, options.Count); // 未割当 + 2ユーザー
+        Assert.Equal("ユーザー1", options[1].TextContent);
+        Assert.Equal("1", options[1].GetAttribute("value"));
+        Assert.Equal("ユーザー2", options[2].TextContent);
+        Assert.Equal("2", options[2].GetAttribute("value"));
+    }
+
+    [Fact]
+    public void 未割当オプションが含まれる()
+    {
+        // Arrange
+        _mockUserApiClient.UsersToReturn = [];
+
+        // Act
+        var cut = RenderComponent<UserSelect>();
+        cut.WaitForState(() => cut.FindAll("option").Count >= 1);
+
+        // Assert
+        var options = cut.FindAll("option");
+        Assert.Single(options);
+        Assert.Equal("", options[0].GetAttribute("value"));
+        Assert.Contains("未割当", options[0].TextContent);
+    }
+
+    [Fact]
+    public void 選択変更時にEventCallbackが呼ばれる()
+    {
+        // Arrange
+        var users = new List<UserResponse>
+        {
+            new(1, "user1@example.com", "ユーザー1", UserRole.Member),
+        };
+        _mockUserApiClient.UsersToReturn = users;
+
+        int? selectedUserId = null;
+        var cut = RenderComponent<UserSelect>(parameters => parameters
+            .Add(p => p.SelectedUserIdChanged, value => selectedUserId = value));
+        cut.WaitForState(() => cut.FindAll("option").Count > 1);
+
+        // Act
+        cut.Find("select").Change("1");
+
+        // Assert
+        Assert.Equal(1, selectedUserId);
+    }
+
+    [Fact]
+    public void 選択変更で未割当を選ぶとnullが返る()
+    {
+        // Arrange
+        var users = new List<UserResponse>
+        {
+            new(1, "user1@example.com", "ユーザー1", UserRole.Member),
+        };
+        _mockUserApiClient.UsersToReturn = users;
+
+        int? selectedUserId = 1;
+        var cut = RenderComponent<UserSelect>(parameters => parameters
+            .Add(p => p.SelectedUserId, 1)
+            .Add(p => p.SelectedUserIdChanged, value => selectedUserId = value));
+        cut.WaitForState(() => cut.FindAll("option").Count > 1);
+
+        // Act
+        cut.Find("select").Change("");
+
+        // Assert
+        Assert.Null(selectedUserId);
+    }
+
+    [Fact]
+    public void ローディング中はdisabledになる()
+    {
+        // Arrange - API呼び出しが完了しないようにする
+        _mockUserApiClient.DelayMs = 10000;
+        _mockUserApiClient.UsersToReturn = [new(1, "user1@example.com", "ユーザー1", UserRole.Member)];
+
+        // Act
+        var cut = RenderComponent<UserSelect>();
+
+        // Assert
+        var select = cut.Find("select");
+        Assert.True(select.HasAttribute("disabled"));
+    }
+
+    [Fact]
+    public void カスタムラベルが表示される()
+    {
+        // Arrange
+        _mockUserApiClient.UsersToReturn = [];
+
+        // Act
+        var cut = RenderComponent<UserSelect>(parameters => parameters
+            .Add(p => p.Label, "レビュアー"));
+        cut.WaitForState(() => cut.FindAll("option").Count >= 1);
+
+        // Assert
+        var label = cut.Find("label");
+        Assert.Equal("レビュアー", label.TextContent);
+    }
+
+    [Fact]
+    public void デフォルトラベルは担当者()
+    {
+        // Arrange
+        _mockUserApiClient.UsersToReturn = [];
+
+        // Act
+        var cut = RenderComponent<UserSelect>();
+        cut.WaitForState(() => cut.FindAll("option").Count >= 1);
+
+        // Assert
+        var label = cut.Find("label");
+        Assert.Equal("担当者", label.TextContent);
+    }
+
+    [Fact]
+    public void SelectedUserIdで初期選択値が設定される()
+    {
+        // Arrange
+        var users = new List<UserResponse>
+        {
+            new(1, "user1@example.com", "ユーザー1", UserRole.Member),
+            new(2, "user2@example.com", "ユーザー2", UserRole.Admin),
+        };
+        _mockUserApiClient.UsersToReturn = users;
+
+        // Act
+        var cut = RenderComponent<UserSelect>(parameters => parameters
+            .Add(p => p.SelectedUserId, 2));
+        cut.WaitForState(() => cut.FindAll("option").Count > 1);
+
+        // Assert
+        var select = cut.Find("select");
+        Assert.Equal("2", select.GetAttribute("value"));
+    }
+
+    /// <summary>
+    /// IUserApiClient のテスト用モック実装
+    /// </summary>
+    private class Mock_UserApiClient : IUserApiClient
+    {
+        public List<UserResponse> UsersToReturn { get; set; } = [];
+        public int DelayMs { get; set; } = 0;
+
+        public async Task<List<UserResponse>> GetUsersAsync()
+        {
+            if (DelayMs > 0)
+                await Task.Delay(DelayMs);
+            return UsersToReturn;
+        }
+    }
+}

--- a/tests/TodoApp.Client.Tests/TodoApp.Client.Tests.csproj
+++ b/tests/TodoApp.Client.Tests/TodoApp.Client.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="bunit" Version="1.36.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
## 概要
- ユーザー選択ドロップダウンコンポーネント（UserSelect.razor）を作成
- 未割当オプション、ローディング中disabled、カスタムラベル対応
- IUserApiClient/UserApiClient を依存として追加

## 関連 Issue
Closes #29

## テスト計画
- [x] ユーザー一覧がドロップダウンに表示される
- [x] 選択変更時に EventCallback が呼ばれる
- [x] 未割当オプションが含まれる
- [x] ローディング中の表示テスト
- [x] カスタムラベル表示テスト
- [x] 初期選択値の反映テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)