### PR TITLE
feat: ログイン画面を実装 (#24)

### DIFF
--- a/src/TodoApp.Client/Pages/Login.razor
+++ b/src/TodoApp.Client/Pages/Login.razor
@@ -1,0 +1,69 @@
+@page "/login"
+@using TodoApp.Client.Services
+@using TodoApp.Shared.Requests
+@inject IAuthApiClient AuthApiClient
+@inject AuthStateProvider AuthStateProvider
+@inject NavigationManager NavigationManager
+
+<h3>ログイン</h3>
+
+<EditForm Model="@_loginRequest" OnValidSubmit="HandleLogin" FormName="LoginForm">
+    <DataAnnotationsValidator />
+
+    <div class="mb-3">
+        <label for="email" class="form-label">メールアドレス</label>
+        <InputText id="email" type="email" class="form-control" @bind-Value="_loginRequest.Email" />
+        <ValidationMessage For="@(() => _loginRequest.Email)" />
+    </div>
+
+    <div class="mb-3">
+        <label for="password" class="form-label">パスワード</label>
+        <InputText id="password" type="password" class="form-control" @bind-Value="_loginRequest.Password" />
+        <ValidationMessage For="@(() => _loginRequest.Password)" />
+    </div>
+
+    @if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <div class="alert alert-danger" role="alert">
+            @_errorMessage
+        </div>
+    }
+
+    <button type="submit" class="btn btn-primary">ログイン</button>
+</EditForm>
+
+<div class="mt-3">
+    <a href="register">ユーザー登録はこちら</a>
+</div>
+
+@code {
+    private LoginRequest _loginRequest = new() { Email = "", Password = "" };
+    private string? _errorMessage;
+
+    private async Task HandleLogin()
+    {
+        _errorMessage = null;
+
+        try
+        {
+            var response = await AuthApiClient.LoginAsync(_loginRequest);
+            if (response.Token is not null)
+            {
+                await AuthStateProvider.MarkUserAsAuthenticatedAsync(response.Token);
+                NavigationManager.NavigateTo("/todos");
+            }
+            else
+            {
+                _errorMessage = "ログインに失敗しました。";
+            }
+        }
+        catch (HttpRequestException)
+        {
+            _errorMessage = "メールアドレスまたはパスワードが正しくありません。";
+        }
+        catch (Exception)
+        {
+            _errorMessage = "ログイン中にエラーが発生しました。";
+        }
+    }
+}

--- a/src/TodoApp.Client/Program.cs
+++ b/src/TodoApp.Client/Program.cs
@@ -1,11 +1,17 @@
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using TodoApp.Client;
+using TodoApp.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<AuthStateProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<AuthStateProvider>());
+builder.Services.AddScoped<IAuthApiClient, AuthApiClient>();
+builder.Services.AddAuthorizationCore();
 
 await builder.Build().RunAsync();

--- a/src/TodoApp.Client/Services/AuthApiClient.cs
+++ b/src/TodoApp.Client/Services/AuthApiClient.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+using TodoApp.Shared.Requests;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Services;
+
+public class AuthApiClient : IAuthApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public AuthApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<AuthResponse> RegisterAsync(RegisterRequest request)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/auth/register", request);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<AuthResponse>()
+            ?? throw new InvalidOperationException("レスポンスのデシリアライズに失敗しました。");
+    }
+
+    public async Task<AuthResponse> LoginAsync(LoginRequest request)
+    {
+        var response = await _httpClient.PostAsJsonAsync("api/auth/login", request);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<AuthResponse>()
+            ?? throw new InvalidOperationException("レスポンスのデシリアライズに失敗しました。");
+    }
+
+    public async Task<UserResponse> GetMeAsync()
+    {
+        var response = await _httpClient.GetAsync("api/auth/me");
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<UserResponse>()
+            ?? throw new InvalidOperationException("レスポンスのデシリアライズに失敗しました。");
+    }
+}

--- a/src/TodoApp.Client/Services/AuthStateProvider.cs
+++ b/src/TodoApp.Client/Services/AuthStateProvider.cs
@@ -1,0 +1,78 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.JSInterop;
+
+namespace TodoApp.Client.Services;
+
+public class AuthStateProvider : AuthenticationStateProvider
+{
+    private const string TokenKey = "authToken";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly HttpClient _httpClient;
+
+    public AuthStateProvider(IJSRuntime jsRuntime, HttpClient httpClient)
+    {
+        _jsRuntime = jsRuntime;
+        _httpClient = httpClient;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var token = await _jsRuntime.InvokeAsync<string>("localStorage.getItem", TokenKey);
+
+        if (string.IsNullOrEmpty(token))
+        {
+            return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+        }
+
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var claims = ParseClaimsFromJwt(token);
+        var identity = new ClaimsIdentity(claims, "jwt");
+        var user = new ClaimsPrincipal(identity);
+
+        return new AuthenticationState(user);
+    }
+
+    public virtual async Task MarkUserAsAuthenticatedAsync(string token)
+    {
+        await _jsRuntime.InvokeVoidAsync("localStorage.setItem", TokenKey, token);
+
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+
+        var claims = ParseClaimsFromJwt(token);
+        var identity = new ClaimsIdentity(claims, "jwt");
+        var user = new ClaimsPrincipal(identity);
+
+        NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(user)));
+    }
+
+    public virtual async Task MarkUserAsLoggedOutAsync()
+    {
+        await _jsRuntime.InvokeVoidAsync("localStorage.removeItem", TokenKey);
+
+        _httpClient.DefaultRequestHeaders.Authorization = null;
+
+        var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+        NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(anonymous)));
+    }
+
+    private static IEnumerable<Claim> ParseClaimsFromJwt(string token)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(token);
+            return jwtToken.Claims;
+        }
+        catch
+        {
+            return Enumerable.Empty<Claim>();
+        }
+    }
+}

--- a/src/TodoApp.Client/Services/IAuthApiClient.cs
+++ b/src/TodoApp.Client/Services/IAuthApiClient.cs
@@ -1,0 +1,11 @@
+using TodoApp.Shared.Requests;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Services;
+
+public interface IAuthApiClient
+{
+    Task<AuthResponse> RegisterAsync(RegisterRequest request);
+    Task<AuthResponse> LoginAsync(LoginRequest request);
+    Task<UserResponse> GetMeAsync();
+}

--- a/src/TodoApp.Client/TodoApp.Client.csproj
+++ b/src/TodoApp.Client/TodoApp.Client.csproj
@@ -8,7 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TodoApp.Client/_Imports.razor
+++ b/src/TodoApp.Client/_Imports.razor
@@ -5,6 +5,10 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.JSInterop
 @using TodoApp.Client
 @using TodoApp.Client.Layout
+@using TodoApp.Client.Services
+@using TodoApp.Shared.Requests
+@using TodoApp.Shared.Responses

--- a/tests/TodoApp.Client.Tests/Pages/LoginTests.cs
+++ b/tests/TodoApp.Client.Tests/Pages/LoginTests.cs
@@ -1,0 +1,144 @@
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Moq;
+using TodoApp.Client.Pages;
+using TodoApp.Client.Services;
+using TodoApp.Shared.Requests;
+using TodoApp.Shared.Responses;
+
+namespace TodoApp.Client.Tests.Pages;
+
+public class LoginTests : TestContext
+{
+    private readonly Mock<IAuthApiClient> _mockAuthApiClient;
+    private readonly FakeAuthStateProvider _fakeAuthStateProvider;
+
+    public LoginTests()
+    {
+        _mockAuthApiClient = new Mock<IAuthApiClient>();
+        _fakeAuthStateProvider = new FakeAuthStateProvider();
+
+        Services.AddSingleton(_mockAuthApiClient.Object);
+        Services.AddSingleton<AuthStateProvider>(_fakeAuthStateProvider);
+        Services.AddSingleton<AuthenticationStateProvider>(_fakeAuthStateProvider);
+    }
+
+    [Fact]
+    public void Login_ページが正しくレンダリングされること()
+    {
+        // Act
+        var cut = RenderComponent<Login>();
+
+        // Assert - メールアドレス入力フィールドが存在する
+        var emailInput = cut.Find("input[type='email']");
+        Assert.NotNull(emailInput);
+
+        // パスワード入力フィールドが存在する
+        var passwordInput = cut.Find("input[type='password']");
+        Assert.NotNull(passwordInput);
+
+        // ログインボタンが存在する
+        var submitButton = cut.Find("button[type='submit']");
+        Assert.NotNull(submitButton);
+        Assert.Contains("ログイン", submitButton.TextContent);
+
+        // ユーザー登録リンクが存在する
+        var registerLink = cut.Find("a[href='register']");
+        Assert.NotNull(registerLink);
+    }
+
+    [Fact]
+    public async Task ログイン成功時にTodo一覧に遷移すること()
+    {
+        // Arrange
+        var authResponse = new AuthResponse
+        {
+            UserId = 1,
+            Email = "test@example.com",
+            DisplayName = "テストユーザー",
+            Token = "dummy-jwt-token"
+        };
+
+        _mockAuthApiClient
+            .Setup(x => x.LoginAsync(It.IsAny<LoginRequest>()))
+            .ReturnsAsync(authResponse);
+
+        var navMan = Services.GetRequiredService<NavigationManager>();
+        var cut = RenderComponent<Login>();
+
+        // Act - フォームに値を入力
+        cut.Find("input[type='email']").Change("test@example.com");
+        cut.Find("input[type='password']").Change("password123");
+        await cut.Find("form").SubmitAsync();
+
+        // Assert
+        _mockAuthApiClient.Verify(
+            x => x.LoginAsync(It.Is<LoginRequest>(r =>
+                r.Email == "test@example.com" && r.Password == "password123")),
+            Times.Once);
+
+        Assert.True(_fakeAuthStateProvider.IsAuthenticated);
+        Assert.Equal("dummy-jwt-token", _fakeAuthStateProvider.LastToken);
+        Assert.EndsWith("/todos", navMan.Uri);
+    }
+
+    [Fact]
+    public async Task ログイン失敗時にエラーメッセージを表示すること()
+    {
+        // Arrange
+        _mockAuthApiClient
+            .Setup(x => x.LoginAsync(It.IsAny<LoginRequest>()))
+            .ThrowsAsync(new HttpRequestException("Unauthorized"));
+
+        var cut = RenderComponent<Login>();
+
+        // Act
+        cut.Find("input[type='email']").Change("test@example.com");
+        cut.Find("input[type='password']").Change("wrongpassword");
+        await cut.Find("form").SubmitAsync();
+
+        // Assert - エラーメッセージが表示される
+        var errorMessage = cut.Find("[role='alert']");
+        Assert.NotNull(errorMessage);
+        Assert.NotEmpty(errorMessage.TextContent);
+    }
+
+    [Fact]
+    public async Task バリデーションエラー時にAPIが呼ばれないこと()
+    {
+        // Arrange
+        var cut = RenderComponent<Login>();
+
+        // Act - 空のまま送信
+        await cut.Find("form").SubmitAsync();
+
+        // Assert - API は呼ばれない
+        _mockAuthApiClient.Verify(
+            x => x.LoginAsync(It.IsAny<LoginRequest>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// テスト用の AuthStateProvider フェイク実装
+    /// </summary>
+    private class FakeAuthStateProvider : AuthStateProvider
+    {
+        public bool IsAuthenticated { get; private set; }
+        public string? LastToken { get; private set; }
+
+        public FakeAuthStateProvider()
+            : base(Mock.Of<IJSRuntime>(), new HttpClient())
+        {
+        }
+
+        public override Task MarkUserAsAuthenticatedAsync(string token)
+        {
+            IsAuthenticated = true;
+            LastToken = token;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/TodoApp.Client.Tests/TodoApp.Client.Tests.csproj
+++ b/tests/TodoApp.Client.Tests/TodoApp.Client.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="bunit" Version="1.36.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## 概要
- EditForm + DataAnnotationsValidator によるバリデーション付きログインフォーム
- ログイン成功時に AuthStateProvider で認証状態を更新し /todos に遷移
- ログイン失敗時にエラーメッセージ表示
- ユーザー登録画面（/register）へのリンク

## 関連 Issue
Closes #24

## テスト計画
- [x] ページレンダリングテスト
- [x] ログイン成功時の遷移テスト
- [x] ログイン失敗時のエラー表示テスト
- [x] バリデーションテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)