### PR TITLE
feat: APIサーバーでBlazor WASMをホストする統合構成を追加 (#78)

### DIFF
--- a/src/TodoApp.Api/Program.cs
+++ b/src/TodoApp.Api/Program.cs
@@ -45,6 +45,8 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
+app.UseBlazorFrameworkFiles();
+app.UseStaticFiles();
 app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
@@ -90,6 +92,8 @@ app.MapGet("/weatherforecast", () =>
 
 app.MapGet("/test/auth", () => "Authenticated!")
     .RequireAuthorization();
+
+app.MapFallbackToFile("index.html");
 
 app.Run();
 

--- a/src/TodoApp.Api/TodoApp.Api.csproj
+++ b/src/TodoApp.Api/TodoApp.Api.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -18,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TodoApp.Client\TodoApp.Client.csproj" />
     <ProjectReference Include="..\TodoApp.Shared\TodoApp.Shared.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- APIサーバー（TodoApp.Api）でBlazor WebAssemblyクライアントをホストするHosted Blazor WASMパターンを実装
- `dotnet run --project src/TodoApp.Api` だけでAPI + UI両方が起動可能に
- CORS設定不要（同一オリジン）

## Changes
- **TodoApp.Api.csproj**: `TodoApp.Client` プロジェクト参照と `Microsoft.AspNetCore.Components.WebAssembly.Server` パッケージを追加
- **Program.cs**: `UseBlazorFrameworkFiles()`, `UseStaticFiles()`, `MapFallbackToFile("index.html")` の3行を追加

## Test plan
- [ ] `dotnet test` で全202テスト（バックエンド82 + フロントエンド120）がパスすること
- [ ] `dotnet run --project src/TodoApp.Api` でサーバー起動後、ブラウザでルートURLにアクセスしてBlazor UIが表示されること
- [ ] 既存APIエンドポイント（`/api/auth`, `/api/todos`, `/api/users`）が正常動作すること

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)